### PR TITLE
-- fix a bug that the resolution changes every time when the key "F9"…

### DIFF
--- a/script/apps/Aries/Creator/Game/Movie/VideoRecorder.lua
+++ b/script/apps/Aries/Creator/Game/Movie/VideoRecorder.lua
@@ -111,10 +111,12 @@ function VideoRecorder.AdjustWindowResolution(callbackFunc)
 	local att = ParaEngine.GetAttributeObject();
 	local cur_resolution = att:GetField("WindowResolution", {400, 300}); 
 	local preferred_resolution = VideoRecorderSettings.GetResolution();
-	-- reserve place for render borders which indicates whether the screen is being recorded or not
+	
+	-- reserve space in resolution for render borders which indicates whether the screen is being recorded or not
 	local margin = VideoRecorderSettings.GetMargin();
 	preferred_resolution[1] = preferred_resolution[1] + margin*2;
 	preferred_resolution[2] = preferred_resolution[2] + margin*2;
+	
 	if(cur_resolution[1] > max_resolution[1] or cur_resolution[2] > max_resolution[2]) then
 		if(not preferred_resolution or not preferred_resolution[1]) then
 			preferred_resolution = max_resolution;
@@ -139,6 +141,11 @@ function VideoRecorder.AdjustWindowResolution(callbackFunc)
 		end})
 		mytimer:Change(100, nil);
 	end
+	
+	-- restore resolution from margins that reserved for borders
+	preferred_resolution[1] = preferred_resolution[1] - margin*2;
+	preferred_resolution[2] = preferred_resolution[2] - margin*2;
+	VideoRecorderSettings.SetResolution(preferred_resolution);
 end
 
 function VideoRecorder.RestoreWindowResolution()

--- a/script/apps/Aries/Creator/Game/Movie/VideoRecorderSettings.lua
+++ b/script/apps/Aries/Creator/Game/Movie/VideoRecorderSettings.lua
@@ -166,6 +166,10 @@ function VideoRecorderSettings.GetResolution()
 	return settings.VideoResolution;
 end
 
+function VideoRecorderSettings.SetResolution(resolution)
+	settings.VideoResolution = resolution;
+end
+
 function VideoRecorderSettings.GetVideoBitRate()
 	return settings.VideoBitRate;
 end


### PR DESCRIPTION
… pressed

-- reserve space in resolution for borders rendering which indicates whether the screen is being recorded or not
-- add a new method SetResolution(new_resolution) to class VideoRecorderSettings as to restore resolution from margins that reserved for borders