### PR TITLE
fix audio file missing problem when recording 1080p movie

### DIFF
--- a/script/apps/Aries/Creator/Game/Movie/VideoRecorder.lua
+++ b/script/apps/Aries/Creator/Game/Movie/VideoRecorder.lua
@@ -49,6 +49,7 @@ function VideoRecorder.BeginCapture(callbackFunc)
 	if(VideoRecorder.HasFFmpegPlugin()) then
 		VideoRecorderSettings.ShowPage(function(res)
 			if(res == "ok") then
+				AudioEngine.SetGarbageCollectThreshold(64);
 				VideoRecorder.AdjustWindowResolution(function()
 					local start_after_seconds = VideoRecorderSettings.start_after_seconds or 0;
 					local elapsed_seconds = 0;
@@ -161,6 +162,7 @@ function VideoRecorder.RestoreWindowResolution()
 end
 
 function VideoRecorder.EndCapture()
+	AudioEngine.SetGarbageCollectThreshold(10);
 	ParaMovie.EndCapture();
 	VideoRecorder.ShowRecordingArea(false);
 	GameLogic.options:SetClickToContinue(true);

--- a/script/apps/Aries/Creator/Game/Movie/VideoRecorderSettings.lua
+++ b/script/apps/Aries/Creator/Game/Movie/VideoRecorderSettings.lua
@@ -60,7 +60,7 @@ local presets = {
 		Codec="mp4",
 		VideoResolution={1920, 1080},
 		VideoBitRate = 7776000, 
-		FPS = 60, 
+		FPS = 30, 
 		margin = 16,
 		stereo = 0,
 	},


### PR DESCRIPTION
-- set 1080p default FPS to 30 instead of 60 since 30 is good enough for IPTV show

-- set AudioEngine's garbage collecting threshold to 64 when movie recording starts and back to default value 10 when it finishes