### PR TITLE
collect user data by GA events

### DIFF
--- a/script/apps/Aries/Creator/Game/ParacraftFilters.md
+++ b/script/apps/Aries/Creator/Game/ParacraftFilters.md
@@ -73,7 +73,7 @@ This givens an overview of filters in paracraft. Please search the source code o
   - "desktop_menu", menu_items:
   - "new_item", itemStackArray, self:
   - "item_client_new_item_type_added", block_id, item:
-  - "user_event_stat", name, value:
+  - "user_event_stat", category, action, value:
 - file exporters:
   - "file_exported", id, filename:
   - "GetExporters", exporters: file exporters

--- a/script/apps/Aries/Creator/Game/Tasks/CreateBlockTask.lua
+++ b/script/apps/Aries/Creator/Game/Tasks/CreateBlockTask.lua
@@ -96,7 +96,7 @@ function CreateBlock:Run()
 				GameLogic.PlayAnimation({facingTarget = {x=tx, y=ty, z=tz},});
 				GameLogic.events:DispatchEvent({type = "CreateBlockTask" , block_id = self.block_id, block_data = block_data, x = self.blockX, y = self.blockY, z = self.blockZ,
 					last_block_id = self.last_block_id, last_block_data = self.last_block_data});
-				GameLogic.GetFilters():apply_filters("user_event_stat", "user/create/block/"..tostring(self.block_id));
+				GameLogic.GetFilters():apply_filters("user_event_stat", "block", "create", tostring(self.block_id));
 			end
 
 			if(GameLogic.GameMode:CanAddToHistory()) then


### PR DESCRIPTION
GA 用来收集 网站数据，电商数据多一些，我们要从 paracraft 里用 api 收集数据去做分析，只能通过它们所收集的数据格式。
一种想法是，将整个 app 当做一个 site，其中所发生的所要收集的数据都当做一个 pageview，比如创建方块  /block/create/62
还有一种想法是，用事件的形式，其中所要记录的数据当做一个 event，比如 category=block, action=create, value=62, label=paracraft

这里使用了 event 接口，可能使后续的分类和整理更为清晰