### PR TITLE
Remove invalid condition judgment

### DIFF
--- a/script/apps/Aries/Creator/Game/Movie/MovieClipController.lua
+++ b/script/apps/Aries/Creator/Game/Movie/MovieClipController.lua
@@ -68,11 +68,10 @@ function MovieClipController.OnClosePage()
 	self.RestoreFocusToCurrentPlayer();
 	Game.SelectionManager:Disconnect("selectedActorChanged", self, self.OnSelectedActorChange);
 	
-	if(GameLogic.IsServerWorld() or GameLogic.IsRemoteWorld()) then
-		if(self.activeClip and self.activeClip:GetEntity()) then
-			self.activeClip:GetEntity():MarkForUpdate();
-		end
-	end
+    if(self.activeClip and self.activeClip:GetEntity()) then
+        self.activeClip:GetEntity():MarkForUpdate();
+    end
+
 	MovieClipController:OnActiveMovieClipChange(nil);
 end
 


### PR DESCRIPTION
方块更新的标记与世界类型无关, 建议去掉世界类型判断, 方块信息更新即标记. 以便其它场景可以正确捕捉方块更新事件.